### PR TITLE
Delay calls to setBarPostion

### DIFF
--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -148,7 +148,6 @@ export default class Toolbar extends Component {
       this.refs.arrow.style.left = "";
     }
     if (this.props.shouldDisplayToolbarFn()) {
-      debugger;
       return this.setBarPosition();
     } else {
       if (this.state.show) {

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -8,7 +8,7 @@ import React, {Component} from "react";
 import {EditorState, RichUtils} from "draft-js";
 import classNames from "classnames";
 import ToolbarItem from "./ToolbarItem";
-import {getSelectionCoords} from "../utils";
+import {getSelectionCoords, delayCall} from "../utils";
 
 
 export default class Toolbar extends Component {
@@ -31,6 +31,7 @@ export default class Toolbar extends Component {
     this.removeEntity = ::this.removeEntity;
     this.setError = ::this.setError;
     this.cancelError = ::this.cancelError;
+    this.setBarPosition = delayCall(::this.setBarPosition);
   }
 
   toggleInlineStyle(inlineStyle) {
@@ -147,6 +148,7 @@ export default class Toolbar extends Component {
       this.refs.arrow.style.left = "";
     }
     if (this.props.shouldDisplayToolbarFn()) {
+      debugger;
       return this.setBarPosition();
     } else {
       if (this.state.show) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -77,3 +77,32 @@ export function createTypeStrategy(type) {
     );
   };
 }
+
+/**
+ * Returns a wrapper for the given function which cannot be called
+ * more often than the given interval. Every time the wrapper is called
+ * a timeout gets reset to the interval's number of ms before calling the fn.
+ *
+ * Keep attention to bind the correct context to the provided funtion using bind() or '::'!
+ *
+ * @export
+ * @param {function} fn The function to execute after the given interval.
+ * @param {number} [interval=100] The interval to wait for before calling the wrapped function.
+ * @example
+ * ```
+ * const delayedLog = delayCall(::console.log, 200);
+ * delayedLog('hans');
+ * delayedLog('heiri');
+ * // logs 'heiri' after 200ms, 'hans' won't be logged at all.
+ * ```
+ * @returns {void}
+ */
+export function delayCall(fn, interval = 100) {
+  let timeout;
+  return function (...args) {
+    if (timeout) {
+      window.clearTimeout(timeout);
+    }
+    window.setTimeout(() => fn.apply(window, args), interval);
+  };
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -103,6 +103,6 @@ export function delayCall(fn, interval = 100) {
     if (timeout) {
       window.clearTimeout(timeout);
     }
-    window.setTimeout(() => fn.apply(window, args), interval);
+    timeout = window.setTimeout(() => fn.apply(window, args), interval);
   };
 }


### PR DESCRIPTION
Do not call setBarPosition more than every 100ms to prevent possible stack overflows.